### PR TITLE
fix(Composer): Allow 3.1 and up

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
 		"installer-name": "social-feed"
 	},
 	"require": {
-		"silverstripe/cms": "~3.4",
-		"silverstripe/framework": "~3.4",
+		"silverstripe/cms": "~3.1",
+		"silverstripe/framework": "~3.1",
 		"league/oauth2-facebook": "~1.0",
 		"league/oauth2-instagram": "^0.2.2",
 		"abraham/twitteroauth": "^0.6.4"


### PR DESCRIPTION
Looking through the code, no idea why SS 3.1+ isn't supported in composer.
