### PR TITLE
feat(Cache/Fixes): Added caching, Fixes a few Facebook API issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ Within the `SocialFeed` control loop the following values are available:
 - `$Type` - the type of post, either "facebook", "twitter" or "instagram"
 - `$Created` - the creation/posted date of the post
 - `$Data` - all of the data for a single post in the original structure returned from the API's. Read documentation for the API's to see what's available. 
+ 
+## Caching
+
+All SocialMediaProvider::getFeed() calls are cached for 15 minutes and can be cleared either in the CMS or by appending **?socialfeedclearcache=1** in developer mode.
+
+There is also a SocialFeedCacheTask that you can setup as a cronjob on your server to ensure that the end-user never has to wait for your server to make its API calls to Facebook, Twitter, etc and update the various social feed caches.
+
+Alternatively, if you're using the [QueuedJobs](https://github.com/silverstripe-australia/silverstripe-queuedjobs) module, this process will be handled automatically for you, as a queued job is setup to update the cache every 10 minutes.
 
 ## Requirements
 

--- a/code/Providers/SocialFeedProvider.php
+++ b/code/Providers/SocialFeedProvider.php
@@ -11,4 +11,72 @@ class SocialFeedProvider extends DataObject
 		'Label',
 		'Enabled'
 	);
+
+	private static $default_cache_lifetime = 900; // 15 minutes (900 seconds)
+
+	public function getCMSFields() {
+		if (Controller::has_curr())
+		{
+			if (isset($_GET['socialfeedclearcache']) && $_GET['socialfeedclearcache'] == 1 && $this->canEdit()) {
+				$this->clearFeedCache();
+				$url =  Controller::curr()->getRequest()->getVar('url');
+				$urlAndParams = explode('?', $url);
+				Controller::curr()->redirect($urlAndParams[0]);
+			}
+
+			$this->beforeUpdateCMSFields(function($fields) {
+				$cache = $this->getFeedCache();
+				if ($cache !== null && $cache !== false) {
+					$url = Controller::curr()->getRequest()->getVar('url');
+					$url .= '?socialfeedclearcache=1';
+					$fields->addFieldToTab('Root.Main', LiteralField::create('cacheclear', '<a href="'.$url.'" class="field ss-ui-button ui-button" style="max-width: 100px;">Clear Cache</a>'));
+				}
+			});
+		}
+		$fields = parent::getCMSFields();
+		return $fields;
+	}
+
+	public function getFeedCache() {
+		$cache = $this->getCacheFactory();
+		$feedStore = $cache->load($this->ID);
+		if (!$feedStore) {
+			return false;
+		}
+		$feed = unserialize($feedStore);
+		if (!$feed) {
+			return false;
+		}
+		return $feed;
+	}
+
+	public function getFeedCacheExpiry() {
+		$cache = $this->getCacheFactory();
+		$metadata = $cache->getMetadatas($this->ID);
+		if ($metadata && isset($metadata['expire'])) {
+			return $metadata['expire'];
+		}
+		return false;
+	}
+
+	public function setFeedCache(array $feed) {
+		$cache = $this->getCacheFactory();
+		$feedStore = serialize($feed);
+		$result = $cache->save($feedStore, $this->ID);
+		return $result;
+	}
+
+	public function clearFeedCache() {
+		$cache = $this->getCacheFactory();
+		return $cache->remove($this->ID);
+	}
+
+	/**
+	 * @return Zend_Cache_Frontend_Output
+	 */
+	protected function getCacheFactory() {
+		$cache = SS_Cache::factory('SocialFeedProvider');
+		$cache->setLifetime($this->config()->default_cache_lifetime);
+		return $cache;
+	}
 }

--- a/code/Providers/SocialFeedProvider.php
+++ b/code/Providers/SocialFeedProvider.php
@@ -12,8 +12,16 @@ class SocialFeedProvider extends DataObject
 		'Enabled'
 	);
 
+	/**
+	 * Then length of time it takes for the cache to expire
+	 *
+	 * @var int
+	 */
 	private static $default_cache_lifetime = 900; // 15 minutes (900 seconds)
 
+	/**
+	 * @return FieldList
+	 */
 	public function getCMSFields() {
 		if (Controller::has_curr())
 		{
@@ -38,7 +46,10 @@ class SocialFeedProvider extends DataObject
 	}
 
 	/**
-	 * Get feed from provider, will automatically cache the result
+	 * Get feed from provider, will automatically cache the result.
+	 *
+	 * If QueuedJobs module is installed, it will also create a job to update the cache
+	 * 5 minutes before it expires.
 	 *
 	 * @return SS_List
 	 */
@@ -72,6 +83,9 @@ class SocialFeedProvider extends DataObject
 	}
 
 	/**
+	 * Retrieve the providers feed without checking the cache
+	 * first.
+	 *
 	 * @return array
 	 */
 	public function getFeedUncached() {
@@ -79,6 +93,9 @@ class SocialFeedProvider extends DataObject
 	}
 
 	/**
+	 * Get the providers feed from the cache. If there is no cache
+	 * then return false.
+	 *
 	 * @return array
 	 */
 	public function getFeedCache() {
@@ -94,6 +111,11 @@ class SocialFeedProvider extends DataObject
 		return $feed;
 	}
 
+	/**
+	 * Get the time() that the cache expires at.
+	 *
+	 * @return int
+	 */
 	public function getFeedCacheExpiry() {
 		$cache = $this->getCacheFactory();
 		$metadata = $cache->getMetadatas($this->ID);
@@ -103,6 +125,9 @@ class SocialFeedProvider extends DataObject
 		return false;
 	}
 
+	/**
+	 * Set the cache.
+	 */
 	public function setFeedCache(array $feed) {
 		$cache = $this->getCacheFactory();
 		$feedStore = serialize($feed);
@@ -110,6 +135,9 @@ class SocialFeedProvider extends DataObject
 		return $result;
 	}
 
+	/**
+	 * Clear the cache that holds this providers feed.
+	 */
 	public function clearFeedCache() {
 		$cache = $this->getCacheFactory();
 		return $cache->remove($this->ID);

--- a/code/Providers/SocialFeedProviderFacebook.php
+++ b/code/Providers/SocialFeedProviderFacebook.php
@@ -8,7 +8,8 @@ class SocialFeedProviderFacebook extends SocialFeedProvider implements SocialFee
 		'FacebookPageID' => 'Varchar(100)',
 		'FacebookAppID' => 'Varchar(400)',
 		'FacebookAppSecret' => 'Varchar(400)',
-		'AccessToken' => 'Varchar(400)'
+		'AccessToken' => 'Varchar(400)',
+		'FacebookType' => 'Int',
 	);
 
 	private static $singular_name = 'Facebook Provider';
@@ -20,12 +21,20 @@ class SocialFeedProviderFacebook extends SocialFeedProvider implements SocialFee
 		'FacebookPageID'
 	);
 
+	const POSTS_AND_COMMENTS = 0;
+	const POSTS_ONLY = 1;
+	private static $facebook_types = array(
+		self::POSTS_AND_COMMENTS => 'Page Posts and Comments',
+		self::POSTS_ONLY 		 => 'Page Posts Only'
+	);
+
 	private $type = 'facebook';
 
 	public function getCMSFields()
 	{
 		$fields = parent::getCMSFields();
 		$fields->addFieldsToTab('Root.Main', new LiteralField('sf_html_1', '<h4>To get the necessary Facebook API credentials you\'ll need to create a <a href="https://developers.facebook.com/apps" target="_blank">Facebook App.</a></h4><p>&nbsp;</p>'), 'Label');
+		$fields->replaceField('FacebookType', DropdownField::create('FacebookType', 'Facebook Type', $this->config()->facebook_types));
 		$fields->removeByName('AccessToken');
 		return $fields;
 	}
@@ -39,6 +48,8 @@ class SocialFeedProviderFacebook extends SocialFeedProvider implements SocialFee
 	{
 		if ($this->FacebookAppID && $this->FacebookAppSecret) {
 			$this->AccessToken = $this->FacebookAppID . '|' . $this->FacebookAppSecret;
+		} else if ($this->AccessToken) {
+			$this->AccessToken = '';
 		}
 
 		parent::onBeforeWrite();
@@ -67,10 +78,32 @@ class SocialFeedProviderFacebook extends SocialFeedProvider implements SocialFee
 		// https://developers.facebook.com/docs/facebook-login/access-tokens#apptokens
 		$accessToken = ($this->AccessToken) ? $this->AccessToken : $this->siteConfig->SocialFeedFacebookAppID . '|' . $this->siteConfig->SocialFeedFacebookAppSecret;
 
-		// Get all data for the FB page
-		$request = $provider->getRequest('GET', 'https://graph.facebook.com/' . $this->FacebookPageID . '/feed?access_token=' . $accessToken);
-		$result = $provider->getResponse($request);
+		// Setup query params for FB query
+		$queryParameters = array(
+			// Get Facebook timestamps in Unix timestamp format
+			'date_format'  => 'U',
+			// Explicitly supply all known 'fields' as the API was returning a minimal fieldset by default.
+			'fields'	   => 'from,message,message_tags,story,story_tags,picture,source,link,object_id,name,caption,description,icon,privacy,type,status_type,created_time,updated_time,shares,is_hidden,is_expired,likes,comments',
+			'access_token' => $accessToken,
+		);
+		$queryParameters = http_build_query($queryParameters);
 
+		// Get all data for the FB page
+		switch ($this->FacebookType) {
+			case self::POSTS_AND_COMMENTS:
+				$request = $provider->getRequest('GET', 'https://graph.facebook.com/' . $this->FacebookPageID . '/feed?'.$queryParameters);
+			break;
+
+			case self::POSTS_ONLY:
+				$request = $provider->getRequest('GET', 'https://graph.facebook.com/' . $this->FacebookPageID . '/posts?'.$queryParameters);
+			break;
+
+			default:
+				throw new Exception('Invalid FacebookType ('.$this->FacebookType.')');
+			break;
+		}
+		$result = $provider->getResponse($request);
+		
 		return $result['data'];
 	}
 
@@ -93,7 +126,13 @@ class SocialFeedProviderFacebook extends SocialFeedProvider implements SocialFee
 	 */
 	public function getPostUrl($post)
 	{
-		return ($post['actions'][0]['name'] === 'Share') ? $post['actions'][0]['link'] : '';
+		if (isset($post['actions'][0]['name']) && $post['actions'][0]['name'] === 'Share') {
+			return $post['actions'][0]['link'];
+		} else if (isset($post['link']) && $post['link']) {
+			// For $post['type'] === 'link' && $post['status_type'] === 'shared_story'
+			return $post['link'];
+		}
+		return '';
 	}
 
 

--- a/code/Providers/SocialFeedProviderFacebook.php
+++ b/code/Providers/SocialFeedProviderFacebook.php
@@ -65,7 +65,7 @@ class SocialFeedProviderFacebook extends SocialFeedProvider implements SocialFee
 		return $this->type;
 	}
 
-	public function getFeed()
+	public function getFeedUncached()
 	{
 		$provider = new Facebook([
 			'clientId' => $this->FacebookAppID,

--- a/code/Providers/SocialFeedProviderTwitter.php
+++ b/code/Providers/SocialFeedProviderTwitter.php
@@ -43,7 +43,11 @@ class SocialFeedProviderTwitter extends SocialFeedProvider implements SocialFeed
 	{
 		// NOTE: Twitter doesn't implement OAuth 2 so we can't use https://github.com/thephpleague/oauth2-client
 		$connection = new TwitterOAuth($this->ConsumerKey, $this->ConsumerSecret, $this->AccessToken, $this->AccessTokenSecret);
-		return $connection->get('statuses/user_timeline', ['count' => 25, 'exclude_replies' => true]);
+		$result = $connection->get('statuses/user_timeline', ['count' => 25, 'exclude_replies' => true]);
+		if (isset($result->error)) {
+			user_error($result->error, E_USER_WARNING);
+		}
+		return $result;
 	}
 
 	/**

--- a/code/Providers/SocialFeedProviderTwitter.php
+++ b/code/Providers/SocialFeedProviderTwitter.php
@@ -39,7 +39,7 @@ class SocialFeedProviderTwitter extends SocialFeedProvider implements SocialFeed
 		return $this->type;
 	}
 
-	public function getFeed()
+	public function getFeedUncached()
 	{
 		// NOTE: Twitter doesn't implement OAuth 2 so we can't use https://github.com/thephpleague/oauth2-client
 		$connection = new TwitterOAuth($this->ConsumerKey, $this->ConsumerSecret, $this->AccessToken, $this->AccessTokenSecret);

--- a/code/SocialFeedCacheQueuedJob.php
+++ b/code/SocialFeedCacheQueuedJob.php
@@ -1,0 +1,66 @@
+<?php
+
+if (!class_exists('AbstractQueuedJob')) {
+	return;
+}
+
+class SocialFeedCacheQueuedJob extends AbstractQueuedJob {
+	/**
+	 * Set queued job execution time to be 5 minutes before the cache expires
+	 * by default.
+	 */
+	private static $cache_time_offset = -300;
+
+	public function createJob($prov) {
+		$time = $prov->getFeedCacheExpiry();
+		$runDate = date('Y-m-d H:i:s', time());
+		if ($time) {
+			$timeOffset = intval(Config::inst()->get(__CLASS__, 'cache_time_offset'));
+			$time += $timeOffset;
+			$runDate = date('Y-m-d H:i:s', $time);
+		}
+		$class = get_class();
+		singleton('QueuedJobService')->queueJob(new $class($prov), $runDate);
+	}
+
+	public function __construct($provider = null) {
+		if ($provider) {
+			$this->setObject($provider);
+			$this->totalSteps = 1;
+		}
+	}
+
+	public function getTitle() {
+		$provider = $this->getObject();
+		return _t(
+			'SocialFeed.SCHEDULEJOBTITLE',
+			'Social Feed - Update cache for "{label}" ({class})',
+			'',
+			array(
+				'class' => $provider->ClassName,
+				'label' => $provider->Label
+			)
+		);
+	}
+
+	public function process() {
+		if ($prov = $this->getObject()) {
+			$feed = $prov->getFeed();
+			$prov->setFeedCache($feed);
+		}
+		$this->currentStep = 1;
+		$this->isComplete = true;
+	}
+
+	/**
+	 * Called when the job is determined to be 'complete'
+	 */
+	public function afterComplete() {
+		$prov = $this->getObject();
+		if ($prov)
+		{
+			// Create next job
+			singleton(__CLASS__)->createJob($prov);
+		}
+	}
+}

--- a/code/SocialFeedCacheQueuedJob.php
+++ b/code/SocialFeedCacheQueuedJob.php
@@ -11,6 +11,10 @@ class SocialFeedCacheQueuedJob extends AbstractQueuedJob {
 	 */
 	private static $cache_time_offset = -300;
 
+	/**
+	 * Setup job that updates the feed cache 5 minutes before it expires so
+	 * the end-user doesn't experience page-load time slowdown.
+	 */
 	public function createJob($prov) {
 		$time = $prov->getFeedCacheExpiry();
 		$runDate = date('Y-m-d H:i:s', time());
@@ -45,7 +49,7 @@ class SocialFeedCacheQueuedJob extends AbstractQueuedJob {
 
 	public function process() {
 		if ($prov = $this->getObject()) {
-			$feed = $prov->getFeed();
+			$feed = $prov->getFeedUncached();
 			$prov->setFeedCache($feed);
 		}
 		$this->currentStep = 1;

--- a/code/SocialFeedCacheQueuedJob.php
+++ b/code/SocialFeedCacheQueuedJob.php
@@ -8,6 +8,8 @@ class SocialFeedCacheQueuedJob extends AbstractQueuedJob {
 	/**
 	 * Set queued job execution time to be 5 minutes before the cache expires
 	 * by default.
+	 *
+	 * @var int
 	 */
 	private static $cache_time_offset = -300;
 
@@ -34,6 +36,9 @@ class SocialFeedCacheQueuedJob extends AbstractQueuedJob {
 		}
 	}
 
+	/**
+	 * Get the name of the job to show in the QueuedJobsAdmin.
+	 */
 	public function getTitle() {
 		$provider = $this->getObject();
 		return _t(
@@ -47,6 +52,10 @@ class SocialFeedCacheQueuedJob extends AbstractQueuedJob {
 		);
 	}
 
+	/**
+	 * Gets the providers feed and stores it in the
+	 * providers cache.
+	 */
 	public function process() {
 		if ($prov = $this->getObject()) {
 			$feed = $prov->getFeedUncached();

--- a/code/SocialFeedCacheTask.php
+++ b/code/SocialFeedCacheTask.php
@@ -12,7 +12,7 @@ class SocialFeedCacheTask extends BuildTask {
 			foreach ($providers as $prov)
 			{
 				$this->log('Getting feed for #'.$prov->ID.' ('.$prov->ClassName.')');
-				$feed = $prov->getFeed();
+				$feed = $prov->getFeedUncached();
 				$prov->setFeedCache($feed);
 				$this->log('Updated feed cache for #'.$prov->ID.' ('.$prov->ClassName.')');
 			}

--- a/code/SocialFeedCacheTask.php
+++ b/code/SocialFeedCacheTask.php
@@ -1,0 +1,29 @@
+<?php
+
+class SocialFeedCacheTask extends BuildTask {
+	protected $title       = 'Social Feed Pre-Load Task';
+	protected $description = 'Calls getFeed on each SocialFeedProvider and caches it. This task exists so a cronjob can be setup to update social feeds without exposing an end user to slowdown.';
+
+	public function run($request) {
+		$providers = SocialFeedProvider::get();
+		$providers = $providers->toArray();
+		if ($providers)
+		{
+			foreach ($providers as $prov)
+			{
+				$this->log('Getting feed for #'.$prov->ID.' ('.$prov->ClassName.')');
+				$feed = $prov->getFeed();
+				$prov->setFeedCache($feed);
+				$this->log('Updated feed cache for #'.$prov->ID.' ('.$prov->ClassName.')');
+			}
+		}
+		else
+		{
+			$this->log('No SocialFeedProvider exist to be updated.');
+		}
+	}
+
+	public function log($message) {
+		DB::alteration_message($message);
+	}
+}

--- a/code/SocialFeedCacheTask.php
+++ b/code/SocialFeedCacheTask.php
@@ -4,6 +4,9 @@ class SocialFeedCacheTask extends BuildTask {
 	protected $title       = 'Social Feed Pre-Load Task';
 	protected $description = 'Calls getFeed on each SocialFeedProvider and caches it. This task exists so a cronjob can be setup to update social feeds without exposing an end user to slowdown.';
 
+	/**
+	 * Gets the feed for each provider and updates the cache with it.
+	 */
 	public function run($request) {
 		$providers = SocialFeedProvider::get();
 		$providers = $providers->toArray();

--- a/code/SocialFeedControllerExtension.php
+++ b/code/SocialFeedControllerExtension.php
@@ -8,15 +8,28 @@ class SocialFeedControllerExtension extends DataExtension
 		$this->siteConfig = SiteConfig::current_site_config();
 	}
 
+	public function onBeforeInit() 
+	{
+		if (Director::isDev()) {
+			// Allow easy clearing of the cache in dev mode
+			if (isset($_GET['socialfeedclearcache']) && $_GET['socialfeedclearcache'] == 1) {
+				foreach (SocialFeedProvider::get() as $prov) {
+					$prov->clearFeedCache();
+				}
+			}
+		}
+	}
+
 	public function SocialFeed()
 	{
-		$combinedData = $this->getProviderFeed(SocialFeedProviderInstagram::get());
+		$combinedData = array();
+		$combinedData = $this->getProviderFeed(SocialFeedProviderInstagram::get(), $combinedData);
 		$combinedData = $this->getProviderFeed(SocialFeedProviderFacebook::get(), $combinedData);
 		$combinedData = $this->getProviderFeed(SocialFeedProviderTwitter::get(), $combinedData);
 
-		//TODO: normalize and order by creation time
-
-		return new ArrayList($combinedData);
+		$result = new ArrayList($combinedData);
+		$result = $result->sort('Created', 'DESC');
+		return $result;
 	}
 
 	private function getProviderFeed($providers, $data = array())
@@ -24,16 +37,28 @@ class SocialFeedControllerExtension extends DataExtension
 		foreach ($providers as $prov) {
 
 			if (is_subclass_of($prov, 'SocialFeedProvider')) {
+				$feed = $prov->getFeedCache();
 
-				$feed = $prov->getFeed();
+				if (!$feed) {
+				    $feed = $prov->getFeed();
+				    $prov->setFeedCache($feed);
+				    if (class_exists('AbstractQueuedJob')) {
+				    	singleton('SocialFeedCacheQueuedJob')->createJob($prov);
+				    }
+				}
 
-				foreach ($feed as $post) {
-					array_push($data, array(
-						'Type' => $prov->getType(),
-						'Data' => $post,
-						'Created' => $prov->getPostCreated($post),
-						'URL' => $prov->getPostUrl($post)
-					));
+				if ($feed) {
+					foreach ($feed as $post) {
+						$created = SS_Datetime::create();
+						$created->setValue($prov->getPostCreated($post));
+
+						array_push($data, array(
+							'Type' => $prov->getType(),
+							'Data' => $post,
+							'Created' => $created,
+							'URL' => $prov->getPostUrl($post)
+						));
+					}
 				}
 			}
 		}

--- a/code/SocialFeedControllerExtension.php
+++ b/code/SocialFeedControllerExtension.php
@@ -2,12 +2,6 @@
 
 class SocialFeedControllerExtension extends DataExtension
 {
-	public function __construct()
-	{
-		parent::__construct();
-		$this->siteConfig = SiteConfig::current_site_config();
-	}
-
 	public function onBeforeInit() 
 	{
 		if (Director::isDev()) {
@@ -35,29 +29,10 @@ class SocialFeedControllerExtension extends DataExtension
 	private function getProviderFeed($providers, $data = array())
 	{
 		foreach ($providers as $prov) {
-
 			if (is_subclass_of($prov, 'SocialFeedProvider')) {
-				$feed = $prov->getFeedCache();
-
-				if (!$feed) {
-				    $feed = $prov->getFeed();
-				    $prov->setFeedCache($feed);
-				    if (class_exists('AbstractQueuedJob')) {
-				    	singleton('SocialFeedCacheQueuedJob')->createJob($prov);
-				    }
-				}
-
-				if ($feed) {
-					foreach ($feed as $post) {
-						$created = SS_Datetime::create();
-						$created->setValue($prov->getPostCreated($post));
-
-						array_push($data, array(
-							'Type' => $prov->getType(),
-							'Data' => $post,
-							'Created' => $created,
-							'URL' => $prov->getPostUrl($post)
-						));
+				if ($feed = $prov->getFeed()) {
+					foreach ($feed->toArray() as $post) {
+						$data[] = $post;
 					}
 				}
 			}

--- a/templates/includes/SocialFeed.ss
+++ b/templates/includes/SocialFeed.ss
@@ -2,9 +2,11 @@
 	<ol>
 		<% loop SocialFeed %>
 			<li>
+				<% if $URL %>
 				<a href="$URL" target="_blank">
+				<% end_if %>
 					<h4>Type: $Type</h4>
-					<p>Created: $Created</p>
+					<p>Created: $Created.Nice</p>
 
 					<%-- Facebook Post --%>
 					<% if $Type == 'facebook' %>
@@ -22,7 +24,9 @@
 					<% else_if $Type == 'instagram' %>
 						<p><img src="$Data.images.thumbnail.url" alt="" width="$Data.images.thumbnail.width" height="$Data.images.thumbnail.height"></p>
 					<% end_if %>
+				<% if $URL %>
 				</a>
+				<% end_if %>
 			</li>
 		<% end_loop %>
 	</ol>


### PR DESCRIPTION
- Added caching around 'getFeed' data.
- Added two display types for Facebook (for getting posts without wall posts)
- Add non-halting error logging if Twitter feed fails
- Added sorting by created time with aggregating the provider feeds
- Updated created time to wrap in SS_Datetime for consistency
- Fixed Facebook feed to explicitly request fields so that a vanilla Facebook app setup will get the expected data
- Added a job/task for refreshing the cache pre-emptively (to avoid slow page load for certain users)
