### PR TITLE
Fixed image missing, due to api changes.

### DIFF
--- a/code/Providers/SocialFeedProviderTwitter.php
+++ b/code/Providers/SocialFeedProviderTwitter.php
@@ -9,12 +9,14 @@ class SocialFeedProviderTwitter extends SocialFeedProvider implements SocialFeed
 		'ConsumerSecret' => 'Varchar(400)',
 		'AccessToken' => 'Varchar(400)',
 		'AccessTokenSecret' => 'Varchar(400)',
-        'ScreenName' => 'Varchar',
-		'TweetModeExtended' => 'Boolean'
+		'ScreenName' => 'Varchar',
+		'TweetModeExtended' => 'Boolean',
+		'ShowReTweetedImages' => 'Boolean',
 	);
 
 	private static $field_labels = array (
-		'TweetModeExtended' => 'Extended Mode'
+		'TweetModeExtended' => 'Extended mode (use if images are not showing)',
+		'ShowReTweetedImages' => 'Show images in re-tweets'
 	);
 
 	private static $singular_name = 'Twitter Provider';
@@ -49,11 +51,11 @@ class SocialFeedProviderTwitter extends SocialFeedProvider implements SocialFeed
 	{
 		// NOTE: Twitter doesn't implement OAuth 2 so we can't use https://github.com/thephpleague/oauth2-client
 		$connection = new TwitterOAuth($this->ConsumerKey, $this->ConsumerSecret, $this->AccessToken, $this->AccessTokenSecret);
-        $parameters = ['count' => 25, 'exclude_replies' => true];
-        if($this->ScreenName)
-        {
-            $parameters['screen_name'] = $this->ScreenName;
-        }
+		$parameters = ['count' => 25, 'exclude_replies' => true];
+		if($this->ScreenName)
+		{
+			$parameters['screen_name'] = $this->ScreenName;
+		}
 		if($this->TweetModeExtended)
 		{
 			$parameters['tweet_mode'] = "extended";
@@ -65,7 +67,7 @@ class SocialFeedProviderTwitter extends SocialFeedProvider implements SocialFeed
 		return $result;
 	}
 
-	/** 
+	/**
 	 * @return HTMLText
 	 */
 	public function getPostContent($post) {
@@ -124,6 +126,8 @@ class SocialFeedProviderTwitter extends SocialFeedProvider implements SocialFeed
 	{
 		if(property_exists($post->entities, 'media') && $post->entities->media[0]->media_url_https) {
 			return $post->entities->media[0]->media_url_https;
+		} elseif($this->ShowReTweetedImages && isset($post->retweeted_status) && property_exists($post->retweeted_status, 'entities')&& property_exists($post->retweeted_status->entities, 'media') && $post->retweeted_status->entities->media[0]->media_url_https) {
+			return $post->retweeted_status->entities->media[0]->media_url_https;
 		}
 	}
 }

--- a/code/Providers/SocialFeedProviderTwitter.php
+++ b/code/Providers/SocialFeedProviderTwitter.php
@@ -10,6 +10,11 @@ class SocialFeedProviderTwitter extends SocialFeedProvider implements SocialFeed
 		'AccessToken' => 'Varchar(400)',
 		'AccessTokenSecret' => 'Varchar(400)',
         'ScreenName' => 'Varchar',
+		'TweetModeExtended' => 'Boolean'
+	);
+
+	private static $field_labels = array (
+		'TweetModeExtended' => 'Extended Mode'
 	);
 
 	private static $singular_name = 'Twitter Provider';
@@ -49,6 +54,10 @@ class SocialFeedProviderTwitter extends SocialFeedProvider implements SocialFeed
         {
             $parameters['screen_name'] = $this->ScreenName;
         }
+		if($this->TweetModeExtended)
+		{
+			$parameters['tweet_mode'] = "extended";
+		}
 		$result = $connection->get('statuses/user_timeline', $parameters);
 		if (isset($result->error)) {
 			user_error($result->error, E_USER_WARNING);
@@ -60,7 +69,12 @@ class SocialFeedProviderTwitter extends SocialFeedProvider implements SocialFeed
 	 * @return HTMLText
 	 */
 	public function getPostContent($post) {
-		$text = isset($post->text) ? $post->text : '';
+		$text = '';
+		if($this->TweetModeExtended && isset($post->full_text)) {
+			$text = $post->full_text;
+		} elseif(isset($post->text)) {
+			$text = $post->text;
+		}
 		$text = preg_replace('/(https?:\/\/[a-z0-9\.\/]+)/i', '<a href="$1" target="_blank">$1</a>', $text); 
 
 		$result = DBField::create_field('HTMLText', $text);

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "isaacrankin/silverstripe-social-feed",
+	"name": "magnusbengtsson/silverstripe-social-feed",
 	"description": "A social feed module for fetching content from Facebook and Twitter",
 	"type": "silverstripe-module",
 	"homepage": "http://github.com/isaacrankin/silverstripe-social-feed",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"support": {
-		"issues": "http://github.com/isaacrankin/silverstripe-social-feed/issues"
+		"issues": "http://github.com/magnusbengtsson/silverstripe-social-feed/issues"
 	},
 	"extra": {
 		"installer-name": "social-feed"


### PR DESCRIPTION
Images are not showing due to change in Twitters API.

Issue described here:
https://twittercommunity.com/t/no-media-url-in-reslt-of-statuses-user-timeline-for-some-statuses/74736

Added checkbox to allow "extended mode".
